### PR TITLE
feat: update meeting API Gateway configuration and deployment

### DIFF
--- a/k8s/minicube/deploy.sh
+++ b/k8s/minicube/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Load local secrets (NOT committed to GitHub)
+ENV_FILE="k8s/minicube/secrets/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  export $(cat "$ENV_FILE" | grep -v '#' | xargs)
+else
+  echo "ERROR: .env.local not found at $ENV_FILE"
+  exit 1
+fi
+
+# Create namespace
+echo "Creating namespace..."
+kubectl apply -f k8s/minicube/meeting-app-namespace.yaml
+
+# Deploy secrets with substituted values
+echo "Deploying secrets..."
+envsubst < k8s/minicube/secrets/meeting-api-gateway-secrets.yaml | kubectl apply -f -
+
+# Deploy database service
+echo "Deploying database service..."
+kubectl apply -f k8s/minicube/database/auth-db-service.yaml
+
+# Deploy meeting-api-gateway
+echo "Deploying meeting-api-gateway..."
+kubectl apply -f k8s/minicube/meeting-api-gateway/
+
+# Deploy NATS
+echo "Deploying NATS..."
+kubectl apply -f minikube/nats/
+
+echo "Deployment complete!"
+echo "Run 'minikube tunnel' in another terminal for LoadBalancer access"

--- a/k8s/minicube/meeting-api-gateway/meeting-api-gateway-config.yaml
+++ b/k8s/minicube/meeting-api-gateway/meeting-api-gateway-config.yaml
@@ -4,16 +4,22 @@ metadata:
   name: meeting-api-gateway-config
   namespace: meeting-app
 data:
-  # application configuration
   BASE_URL: 'localhost:3001'
   WEB_APP_URL: 'localhost:3000'
   NODE_ENV: 'development'
   PORT: '3001'
-  KAFKA_BROKER: 'localhost:29092'
+  KAFKA_BROKER: 'nats-service:4222'
   NATS_URL: 'nats://nats-service:4222'
 
-  # jwt configuration (non-sensitive)
   JWT_ACCESS_TOKEN_AUDIENCE: 'meeting-api-gateway'
   JWT_ACCESS_TOKEN_ISSUER: 'meeting-api-gateway'
   JWT_ACCESS_TOKEN_TTL: '3600'
+  JWT_ACCESS_TOKEN_EXPIRATION_TIME: '3600'
+
+  JWT_REFRESH_TOKEN_AUDIENCE: 'meeting-api-gateway'
+  JWT_REFRESH_TOKEN_ISSUER: 'meeting-api-gateway'
   JWT_REFRESH_TOKEN_TTL: '86400'
+  JWT_REFRESH_EXPIRATION_TIME: '86400'
+
+  CACHE_TTL_MS: '60000'
+  REDIS_URL: 'redis://redis.meeting-app.svc.cluster.local:6379/0'

--- a/k8s/minicube/meeting-api-gateway/meeting-api-gateway-deployment.yaml
+++ b/k8s/minicube/meeting-api-gateway/meeting-api-gateway-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: meeting-api-gateway
-          image: oldestspy/meeting-api-gateway:0.0.1
+          image: oldestspy/meeting-api-gateway:0.0.2
           ports:
             - containerPort: 3001
               name: http


### PR DESCRIPTION
- Changed KAFKA_BROKER from 'localhost:29092' to 'nats-service:4222' in meeting-api-gateway-config.yaml for improved service integration.
- Added JWT_ACCESS_TOKEN_EXPIRATION_TIME and JWT_REFRESH_EXPIRATION_TIME to enhance token management.
- Introduced CACHE_TTL_MS and REDIS_URL for caching configuration in meeting-api-gateway-config.yaml.
- Updated the meeting API Gateway image version to 0.0.2 in meeting-api-gateway-deployment.yaml for the latest features and fixes.